### PR TITLE
Introduce selecthandler call back

### DIFF
--- a/src/gchart.js
+++ b/src/gchart.js
@@ -185,6 +185,10 @@ var root = module.exports = function(yasr) {
         chartWrapper.setOption("width", $wrapper.width());
         chartWrapper.setOption("height", $wrapper.height());
         chartWrapper.draw();
+        // introduce handler
+        if ( customOpts.selectHandler && typeof(customOpts.selectHandler) == 'function') 
+				   google.visualization.events.addListener(chartWrapper, "select", function() { customOpts.selectHandler(chartWrapper,jsonResults); });
+        
         google.visualization.events.addListener(chartWrapper, "ready", yasr.updateHeader);
       };
 


### PR DESCRIPTION
By adding a 'selectHandler' property on chartConfig a callback function will be fired whenever someones click in a chart or table
The function has 2 parameters, the ChartWrapper and a jsonSparqlResultset